### PR TITLE
Replace query parameters with header auth

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -73,12 +73,14 @@ module.exports = function(options) {
       const arhiveURL =
         "https://api.github.com/repos/" +
         repo.full_name +
-        "/tarball/master?access_token=" +
-        options.githubAccessToken
+        "/tarball/master?access_token="
       const requestOptions = {
         url: arhiveURL,
         headers: {
-          "User-Agent": "nodejs"
+          "User-Agent": "nodejs",
+          "Accept": "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Authorization": "Bearer " + options.githubAccessToken
         }
       }
 


### PR DESCRIPTION
Query parameter authentication has since been deprecated in 2020 in-lieu of header authentication as per https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/